### PR TITLE
Use GMT Timezone for Guzzle request

### DIFF
--- a/src/Guzzle3/HmacAuthPlugin.php
+++ b/src/Guzzle3/HmacAuthPlugin.php
@@ -88,6 +88,7 @@ class HmacAuthPlugin implements EventSubscriberInterface
 
         if (!$request->hasHeader('Date')) {
             $time = new \DateTime();
+            $time->setTimezone(new \DateTimeZone('GMT'));
             $request->setHeader('Date', $time->format(ClientInterface::HTTP_DATE));
         }
 


### PR DESCRIPTION
If your php config has a timezone different than GMT, a wrong header Date will be set.
